### PR TITLE
feat(WeathenIcon): Create weatherCondition object

### DIFF
--- a/components/TodaysWeather.tsx
+++ b/components/TodaysWeather.tsx
@@ -42,7 +42,7 @@ const TodaysWeather = observer(() => {
   return (
     <View style={container.container}>
       <Animated.Text style={{ opacity: neonAnim }}>
-        <WeatherIcon name="sunny" size="today" />
+        <WeatherIcon name={weatherStore.weatherCondition} size="today" />
       </Animated.Text>
       <Text style={text.light}>{weatherStore.tempCelsius}°C</Text>
       <Text style={text.dark}>{weatherStore.weatherCondition}</Text>

--- a/components/WeatherIcon.tsx
+++ b/components/WeatherIcon.tsx
@@ -1,52 +1,43 @@
 import React from "react";
 import { Ionicons } from "@expo/vector-icons";
-import { StyleSheet } from "react-native";
 import { text } from "../styles/texts";
 
 interface WeatherIconProps {
-  name: "sunny" | "cloudy" | "rainy" | string;
+  name: string | null;
   size: "today" | "weekday";
 }
 
-type IconName =
-  | "sunny-outline"
-  | "cloud-outline"
-  | "rainy-outline"
-  | "help-circle-outline";
+const weatherConditions = {
+  "sunny-outline": { color: "yellow", keywords: ["sun", "overcast", "clear"] },
+  "rainy-outline": {
+    color: "lightblue",
+    keywords: ["rain", "sleet", "drizzle"],
+  },
+  "snow-outline": {
+    color: "white",
+    keywords: ["snow", "freez", "blizzard", "ice"],
+  },
+  "cloud-outline": { color: "grey", keywords: ["cloud", "fog", "mist"] },
+  "reorder-four-outline": { color: "grey", keywords: ["fog"] },
+  "partly-sunny-outline": { color: "yellow", keywords: ["partly cloudy"] },
+  "flash-outline": { color: "yellow", keywords: ["thunder"] },
+};
 
 const WeatherIcon: React.FC<WeatherIconProps> = ({ name, size }) => {
-  let iconName: IconName;
-  let iconColor: string;
-  let iconSize: number;
+  const lowerName = name?.toLowerCase();
+  // Default icon
+  let iconName: keyof typeof weatherConditions = "cloud-outline";
+  let iconColor = "grey";
 
-  switch (name) {
-    case "sunny":
-      iconName = "sunny-outline";
-      iconColor = "yellow";
+  for (const [icon, { color, keywords }] of Object.entries(weatherConditions)) {
+    if (keywords.some((keyword) => lowerName && lowerName.includes(keyword))) {
+      iconName = icon as keyof typeof weatherConditions;
+      iconColor = color;
       break;
-    case "cloudy":
-      iconName = "cloud-outline";
-      iconColor = "grey";
-      break;
-    case "rainy":
-      iconName = "rainy-outline";
-      iconColor = "lightblue";
-      break;
-    default:
-      iconName = "help-circle-outline";
-      iconColor = "black";
+    }
   }
 
-  switch (size) {
-    case "today":
-      iconSize = 160;
-      break;
-    case "weekday":
-      iconSize = 40;
-      break;
-    default:
-      iconSize = 24;
-  }
+  const iconSize = size === "today" ? 160 : 40;
 
   return (
     <Ionicons

--- a/components/WeeklyForecast.tsx
+++ b/components/WeeklyForecast.tsx
@@ -15,7 +15,6 @@ const WeeklyForecast = observer(() => {
         <WeeklyForecastElement
           key={index}
           weatherCondition={day.day?.condition?.text || ""}
-          //AVERAGE TEMP TODO
           tempCelsius={day.day?.avgtemp_c}
           weekday={new Date(day.date).toLocaleDateString("en-US", {
             weekday: "long",

--- a/components/WeeklyForecastElement.tsx
+++ b/components/WeeklyForecastElement.tsx
@@ -15,9 +15,10 @@ const WeeklyForecastElement: React.FC<WeeklyForecastElementProps> = observer(
   ({ weatherCondition, tempCelsius, weekday }) => {
     return (
       <View style={container.weekWeatherElement}>
-        <WeatherIcon name="sunny" size="weekday" />
+        <WeatherIcon name={weatherCondition} size="weekday" />
         <Text style={text.light}>{tempCelsius} °C</Text>
         <Text style={text.light}>{weekday}</Text>
+        <Text style={text.light}>{weatherCondition}</Text>
       </View>
     );
   }


### PR DESCRIPTION
Created weatherCondition object to connect Ionicons iconName to name props that represents weather condition. 
Thanks to this, when entering weatherStore.weatherCondition into the name prop, the icon displayed will depend on the weather conditions.