### PR TITLE
feat(error-ui): Improved response to error state

### DIFF
--- a/stores/ModalStore.tsx
+++ b/stores/ModalStore.tsx
@@ -1,4 +1,5 @@
-import { makeAutoObservable } from "mobx";
+import { makeAutoObservable, reaction } from "mobx";
+import { weatherStore } from "./WeatherStore";
 
 class ModalStore {
   weeklyForecastModalVisible = false;
@@ -7,6 +8,13 @@ class ModalStore {
 
   constructor() {
     makeAutoObservable(this);
+
+    reaction(
+      () => weatherStore.error,
+      (error) => {
+        this.errorModalVisible = error !== "";
+      }
+    );
   }
 
   setDate(date: string) {


### PR DESCRIPTION
Improved response to the error state - when weatherStore.error is not an empty string, the error modal's visibility is set to true.